### PR TITLE
Deprecation of Gutenberg Ramp (branch: main)

### DIFF
--- a/mu-plugins/load-gutenberg1.php
+++ b/mu-plugins/load-gutenberg1.php
@@ -1,10 +1,10 @@
 <?php
 
 if ( defined ( 'IS_PRODUCTION') ) {
-	gutenberg_ramp_load_gutenberg( true ); 
+	add_filter( 'use_block_editor_for_post', '__return_true' ); 
 }
 
 else {
-	gutenberg_ramp_load_gutenberg( false ); 
+	add_filter( 'use_block_editor_for_post', '__return_false' ); 
 }
 

--- a/mu-plugins/load-gutenberg1b.php
+++ b/mu-plugins/load-gutenberg1b.php
@@ -1,10 +1,10 @@
 <?php
 
 if ( defined ( 'IS_PRODUCTION') ) {
-	ramp_for_gutenberg_load_gutenberg( true ); 
+	add_filter( 'use_block_editor_for_post', '__return_true' ); 
 }
 
 else {
-	wpcom_vip_load_gutenberg( false ); 
+	add_filter( 'use_block_editor_for_post', '__return_false' ); 
 }
 

--- a/mu-plugins/load-gutenberg1c.php
+++ b/mu-plugins/load-gutenberg1c.php
@@ -1,31 +1,27 @@
 <?php
 
 if ( defined ( 'IS_PRODUCTION') ) {
-	gutenberg_ramp_load_gutenberg( array( 'load' => 1, ) ); 
+	add_filter( 'use_block_editor_for_post', '__return_true' ); 
 
-	gutenberg_ramp_load_gutenberg( array( 'load' => 1 ) ); 
+	add_filter( 'use_block_editor_for_post', '__return_true' ); 
 
-	gutenberg_ramp_load_gutenberg( array( 'load' => true, ) ); 
+	add_filter( 'use_block_editor_for_post', '__return_true' ); 
 
-	gutenberg_ramp_load_gutenberg( array( 'load' => true ) ); 
+	add_filter( 'use_block_editor_for_post', '__return_true' ); 
 
-	gutenberg_ramp_load_gutenberg( array(
-		'load' => true
-	) ); 
+	add_filter( 'use_block_editor_for_post', '__return_true' ); 
 }
 
 else {
-	gutenberg_ramp_load_gutenberg( array( 'load' => 0, ) ); 
+	add_filter( 'use_block_editor_for_post', '__return_false' ); 
 
-	gutenberg_ramp_load_gutenberg( array( 'load' => 0 ) ); 
+	add_filter( 'use_block_editor_for_post', '__return_false' ); 
 
-	gutenberg_ramp_load_gutenberg( array( 'load' => false, ) ); 
+	add_filter( 'use_block_editor_for_post', '__return_false' ); 
 
-	gutenberg_ramp_load_gutenberg( array( 'load' => false ) ); 
+	add_filter( 'use_block_editor_for_post', '__return_false' ); 
 
-	gutenberg_ramp_load_gutenberg( array(
-		'load' => false
-	) ); 
+	add_filter( 'use_block_editor_for_post', '__return_false' ); 
 
 }
 

--- a/mu-plugins/load-gutenberg1d.php
+++ b/mu-plugins/load-gutenberg1d.php
@@ -1,10 +1,10 @@
 <?php
 
 if ( defined ( 'IS_PRODUCTION') ) {
-	ramp_for_gutenberg_load_gutenberg( array( 'load' => 1 ) ); 
+	add_filter( 'use_block_editor_for_post', '__return_true' ); 
 }
 
 else {
-	wpcom_vip_load_gutenberg( array( 'load' => 0 ) ); 
+	add_filter( 'use_block_editor_for_post', '__return_false' ); 
 }
 

--- a/mu-plugins/load-gutenberg1e.php
+++ b/mu-plugins/load-gutenberg1e.php
@@ -1,10 +1,10 @@
 <?php
 
 if ( defined ( 'IS_PRODUCTION') ) {
-	gutenberg_ramp_load_gutenberg(); 
+	add_filter( 'use_block_editor_for_post', '__return_true' ); 
 }
 
 else {
-	gutenberg_ramp_load_gutenberg( ); 
+	add_filter( 'use_block_editor_for_post', '__return_true' ); 
 }
 

--- a/mu-plugins/load-gutenberg1f.php
+++ b/mu-plugins/load-gutenberg1f.php
@@ -1,31 +1,27 @@
 <?php
 
 if ( defined ( 'IS_PRODUCTION') ) {
-	gutenberg_ramp_load_gutenberg( [ 'load' => 1 ] ); 
+	add_filter( 'use_block_editor_for_post', '__return_true' ); 
 
-	gutenberg_ramp_load_gutenberg( [ 'load' => 1, ] ); 
+	add_filter( 'use_block_editor_for_post', '__return_true' ); 
 
-	gutenberg_ramp_load_gutenberg( [ 'load' => true ] ); 
+	add_filter( 'use_block_editor_for_post', '__return_true' ); 
 
-	gutenberg_ramp_load_gutenberg( [ 'load' => true, ] ); 
+	add_filter( 'use_block_editor_for_post', '__return_true' ); 
 
-	gutenberg_ramp_load_gutenberg(
-		[ 'load' => true, ]
-	); 
+	add_filter( 'use_block_editor_for_post', '__return_true' ); 
 }
 
 else {
-	gutenberg_ramp_load_gutenberg( [ 'load' => 0 ] ); 
+	add_filter( 'use_block_editor_for_post', '__return_false' ); 
 
-	gutenberg_ramp_load_gutenberg( [ 'load' => 0, ] ); 
+	add_filter( 'use_block_editor_for_post', '__return_false' ); 
 
-	gutenberg_ramp_load_gutenberg( [ 'load' => false ] ); 
+	add_filter( 'use_block_editor_for_post', '__return_false' ); 
 
-	gutenberg_ramp_load_gutenberg( [ 'load' => false, ] ); 
+	add_filter( 'use_block_editor_for_post', '__return_false' ); 
 
-	gutenberg_ramp_load_gutenberg( [
-		'load' => false,
-	] ); 
+	add_filter( 'use_block_editor_for_post', '__return_false' ); 
 
 }
 

--- a/mu-plugins/load-gutenberg2.php
+++ b/mu-plugins/load-gutenberg2.php
@@ -1,7 +1,7 @@
 <?php
 
 if ( defined ( 'IS_PRODUCTION') ) {
-	wpcom_vip_load_gutenberg( [ 'post_ids' => [ 500, 6000, 7000, 10000 ] ] );
+	gutenberg_ramp_load_gutenberg( [ 'post_ids' => [ 500, 6000, 7000, 10000 ] ] );
 }
 
 

--- a/mu-plugins/load-gutenberg3.php
+++ b/mu-plugins/load-gutenberg3.php
@@ -1,7 +1,7 @@
 <?php
 
 if ( defined ( 'IS_PRODUCTION') ) {
-	wpcom_vip_load_gutenberg( [ 'post_types' => [ 'post' ] ] );
+	gutenberg_ramp_load_gutenberg( [ 'post_types' => [ 'post' ] ] );
 }
 
 


### PR DESCRIPTION
This PR is needed in order to remove any invocations to Gutenberg Ramp.<br><br>Note that there are a number of files that still will need to be inspected manually, as these contain references to Gutenberg Ramp (calls to `gutenberg_ramp_load_gutenberg()`): 
 
 <a href="https://github.com/gudmdharalds/gutenberg-ramp-removal-test/blob/main/mu-plugins/load-gutenberg3.php">mu-plugins/load-gutenberg3.php</a> 
 <a href="https://github.com/gudmdharalds/gutenberg-ramp-removal-test/blob/main/mu-plugins/load-gutenberg2.php">mu-plugins/load-gutenberg2.php</a>